### PR TITLE
Optimize setTimeout and code

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -6,37 +6,32 @@ export default function Home() {
   const previewRef = useRef(null);
   const descRef = useRef(null);
 
-  function strike(text) {
+  const strike = (text) => {
     return text
       .split("")
       .map((char) => char + "\u0336")
       .join("");
-  }
+  };
 
   const input = (event) => {
     const value = event.target.value;
     descRef.current.innerText =
       "Striked text will automatically be copied to clipboard.";
-    if (value === "") {
-      previewRef.current.innerText = "";
-    } else {
-      previewRef.current.innerText = strike(value);
-    }
+    previewRef.current.innerText = value ? strike(value) : "";
   };
 
   let timeout = null;
-  let cotime = null;
-  function copyText() {
-    const value = previewRef.current.innerHTML;
+  const copyText = () => {
     clearTimeout(timeout);
-    timeout = setTimeout(function () {
-      if(value) navigator.clipboard.writeText(previewRef.current.innerHTML);
-    }, 1000);
-    clearTimeout(cotime);
-    cotime = setTimeout(function () {
-      if(value) descRef.current.innerHTML = `<span class=${styles.span}>Text Copied!</span>`;
-    }, 1000);
-  }
+    const value = previewRef.current.innerHTML;
+
+    if (value) {
+      timeout = setTimeout(() => {
+        navigator.clipboard.writeText(previewRef.current.innerHTML);
+        descRef.current.innerHTML = `<span class=${styles.span}>Text Copied!</span>`;
+      }, 1000);
+    }
+  };
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
1. Removed the second `setTimeout` (cotime) and improve the performance, doing both things (copy text and showing up) in a single one

2. Used the new JS sintax and make a code better readable

If thid pull request is valid, please don't forget add the label `hacktoberfest-accepted` 

### Issue [here](https://github.com/gouravkhunger/nextjs-strikeit/issues/9)
