### PR TITLE
Fixed a bug where the user's cursor jumps back if the user clicked above the text inserted.

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -24,6 +24,8 @@ export default function Home() {
     }
   };
 
+	const setCaretPositionToEnd = (e) => e.target.setSelectionRange(e.target.value.length, e.target.value.length);
+
   let timeout = null;
   let cotime = null;
   function copyText() {
@@ -69,6 +71,7 @@ export default function Home() {
             type="text"
             onChange={input}
             onKeyUp={copyText}
+						onClick={setCaretPositionToEnd}
           />
           <p className={styles.preview} ref={previewRef}></p>
           <p className={styles.desc}>


### PR DESCRIPTION
With this fix now the user's cursor always goes to the end of the line as intended (better user experience).

This PR aims to enhance the user experience by giving a more intuitive behaviour and a less frustrating experience.

Before:
![bugreportandfix-2021-10-03_22 36 02](https://user-images.githubusercontent.com/60916242/135771064-57fb3f36-9ba6-474d-8e62-cba88619ca54.gif)

After:
![bugreportandfix-2021-10-03_22 37 20](https://user-images.githubusercontent.com/60916242/135771075-a14fc358-a371-47d7-aa9c-d32f2f48b2c9.gif)

